### PR TITLE
Use conventional commits for vimdoc commits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
-          commit_message: "auto-generate vimdoc"
+          commit_message: "chore(ci): auto-generate vimdoc"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
Currently autogenerate vimdocs create "autogenerate vimdoc" commit which does not have conventional commit prefix which makes it clutter the release note shown by package managers like lazy.nvim. 

Once added `chore:` it is filtered out like this

<img width="1006" height="133" alt="image" src="https://github.com/user-attachments/assets/0d1517da-bcad-49ed-b0e5-60643b934528" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the commit message used for automated documentation generation in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->